### PR TITLE
Support daily cost centers

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,7 +140,7 @@ class TimeTracker {
 
     validateForm() {
         let isValid = true;
-        const requiredFields = ['employeeName', 'calendarWeek', 'costCenter'];
+        const requiredFields = ['employeeName', 'calendarWeek', 'employeeNumber'];
         
         // Check required fields
         requiredFields.forEach(fieldId => {
@@ -226,7 +226,7 @@ class TimeTracker {
             // Get form data
             const employeeName = document.getElementById('employeeName').value;
             const calendarWeek = document.getElementById('calendarWeek').value;
-            const costCenter = document.getElementById('costCenter').value;
+            const employeeNumber = document.getElementById('employeeNumber').value;
             const currentDate = new Date().toLocaleDateString('de-DE');
 
             // PDF Header
@@ -247,7 +247,7 @@ class TimeTracker {
             doc.setFont(undefined, 'normal');
             doc.text(`Name: ${employeeName}`, 20, 60);
             doc.text(`Kalenderwoche: ${calendarWeek}`, 20, 70);
-            doc.text(`Kostenstelle: ${costCenter}`, 20, 80);
+            doc.text(`Personalnummer: ${employeeNumber}`, 20, 80);
 
             // Table Header
             doc.setFontSize(14);
@@ -262,10 +262,12 @@ class TimeTracker {
                 const startTime = dayEntry.querySelector('.start-time').value || '-';
                 const endTime = dayEntry.querySelector('.end-time').value || '-';
                 const breakDuration = dayEntry.querySelector('.break-duration').value || '0';
+                const costCenter = dayEntry.querySelector('.daily-cost-center').value || '-';
                 const dailyHours = dayEntry.querySelector('.daily-hours').value || '-';
-                
+
                 tableData.push([
                     days[index],
+                    costCenter,
                     startTime,
                     endTime,
                     `${breakDuration} Min`,
@@ -275,8 +277,8 @@ class TimeTracker {
 
             // Draw table
             let yPos = 110;
-            const colWidths = [30, 25, 25, 25, 25];
-            const headers = ['Tag', 'Start', 'Ende', 'Pause', 'Arbeitszeit'];
+            const colWidths = [25, 25, 25, 25, 25, 25];
+            const headers = ['Tag', 'Kostenstelle', 'Start', 'Ende', 'Pause', 'Arbeitszeit'];
 
             // Table headers
             doc.setFontSize(10);

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
                             </div>
                             
                             <div class="form-group flex-1">
-                                <label for="costCenter" class="form-label">Kostenstelle *</label>
-                                <input type="text" id="costCenter" class="form-control" placeholder="z.B. 1001" required>
+                                <label for="employeeNumber" class="form-label">Personalnummer *</label>
+                                <input type="text" id="employeeNumber" class="form-control" placeholder="z.B. 4711" required>
                             </div>
                         </div>
                     </div>
@@ -64,6 +64,10 @@
                                         <input type="number" class="form-control break-duration" value="30" min="0">
                                     </div>
                                     <div class="form-group">
+                                        <label class="form-label">Kostenstelle</label>
+                                        <input type="text" class="form-control daily-cost-center">
+                                    </div>
+                                    <div class="form-group">
                                         <label class="form-label">Arbeitszeit</label>
                                         <input type="text" class="form-control daily-hours" readonly>
                                     </div>
@@ -84,6 +88,10 @@
                                     <div class="form-group">
                                         <label class="form-label">Pause (Min.)</label>
                                         <input type="number" class="form-control break-duration" value="30" min="0">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Kostenstelle</label>
+                                        <input type="text" class="form-control daily-cost-center">
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label">Arbeitszeit</label>
@@ -108,6 +116,10 @@
                                         <input type="number" class="form-control break-duration" value="30" min="0">
                                     </div>
                                     <div class="form-group">
+                                        <label class="form-label">Kostenstelle</label>
+                                        <input type="text" class="form-control daily-cost-center">
+                                    </div>
+                                    <div class="form-group">
                                         <label class="form-label">Arbeitszeit</label>
                                         <input type="text" class="form-control daily-hours" readonly>
                                     </div>
@@ -130,6 +142,10 @@
                                         <input type="number" class="form-control break-duration" value="30" min="0">
                                     </div>
                                     <div class="form-group">
+                                        <label class="form-label">Kostenstelle</label>
+                                        <input type="text" class="form-control daily-cost-center">
+                                    </div>
+                                    <div class="form-group">
                                         <label class="form-label">Arbeitszeit</label>
                                         <input type="text" class="form-control daily-hours" readonly>
                                     </div>
@@ -150,6 +166,10 @@
                                     <div class="form-group">
                                         <label class="form-label">Pause (Min.)</label>
                                         <input type="number" class="form-control break-duration" value="30" min="0">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Kostenstelle</label>
+                                        <input type="text" class="form-control daily-cost-center">
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label">Arbeitszeit</label>


### PR DESCRIPTION
## Summary
- rename costCenter field to employeeNumber
- allow entering a cost center for each day
- include personal number and daily cost centers in PDF export

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bd2011edc8329b0fac882081e1b05